### PR TITLE
Add 3D model export tooling (PCB → GLB → DAE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,15 @@ fp-info-cache
 #auto_saved_files#
 
 production/backups
+
+# Generated 3D models (regenerate with tools/export-3d.sh)
+/bornhack2026-hardware.glb
+/bornhack2026-hardware.dae
+
+# pycollada venv used by the 3D export tooling
+tools/.venv-3d/
+pip-wheel-metadata/
+
+# Python bytecode caches
+__pycache__/
+*.pyc

--- a/readme.md
+++ b/readme.md
@@ -132,3 +132,53 @@ Two 10k pull up resistors are provided on the board, when the capacitance is too
 | A14           | P1.15        | Digital I/O              | LED_GREEN    | LED green (active low, GPIO output)                      |
 | AD6           | D+           | USB                      | USB_D+       | USB data +                                               |
 | AD4           | D-           | USB                      | USB_D-       | USB data -                                               |
+
+## 3D model export
+
+The badge's full 3D model is available as a glTF binary (`.glb`) and a Collada
+(`.dae`). Both are *generated* from the PCB - they are not checked in (see
+`.gitignore`) - so regenerate them whenever the layout changes.
+
+KiCad has no DAE/Collada export target, and Blender 5.0 dropped its own native
+Collada exporter (`bpy.ops.wm.collada_export` is now a non-functional stub). So
+we go in two steps:
+
+1. **PCB -> GLB** with `kicad-cli` (KiCad 10 exports GLB natively).
+2. **GLB -> DAE** inside Blender, importing the GLB and writing the Collada file
+   with [`pycollada`](https://pypi.org/project/pycollada/) (a pure-Python
+   library, so it loads on top of Blender's bundled numpy with no compiled
+   extensions and no changes to your Blender install).
+
+### Usage
+
+One command, from anywhere in the repo:
+
+```sh
+tools/export-3d.sh
+```
+
+This writes `bornhack2026-hardware.glb` and `bornhack2026-hardware.dae` to the
+repo root and prints their final paths and sizes. To convert a different board,
+pass it as the first argument: `tools/export-3d.sh path/to/other.kicad_pcb`.
+
+### Prerequisites
+
+- **KiCad 10** (`kicad-cli` on your `PATH`).
+- **Blender >= 4** (it ships its own Python 3.11+ / 5.0 ships 3.13). The script
+  finds `blender`, `blender-5.0`, `blender-4.5`, etc. on your `PATH`, and on
+  macOS also probes `/Applications/Blender.app`.
+- **python3** to create a small throwaway venv for `pycollada`. On Debian/Ubuntu
+  this means the `python3-venv` package.
+- **Network access on the first run only**, so that venv can `pip install`
+  `pycollada` (pinned for reproducibility). Subsequent runs reuse the cached venv.
+
+You can override the autodetection with environment variables if needed:
+`KICAD_CLI`, `BLENDER`, `KICAD9_3DMODEL_DIR`, `VENV_DIR`, and `OUTDIR`.
+
+### Notes
+
+- The generated `.glb` / `.dae` files and the tooling venv (`tools/.venv-3d/`)
+  are git-ignored - they are large and fully regenerable.
+- During the GLB export KiCad warns that the `FPC1` and `L1` component models are
+  missing. That is **expected and harmless**: those two footprints are not in the
+  standard KiCad 3D model library, so they simply do not appear in the model.

--- a/tools/export-3d.sh
+++ b/tools/export-3d.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# export-3d.sh - regenerate the 3D models (.glb + .dae) for the Cyber Ægg PCB.
+#
+# Pipeline (one deterministic path):
+#   PCB (.kicad_pcb) --kicad-cli--> GLB --Blender + pycollada--> DAE
+#
+# Why two steps?  KiCad has no DAE/Collada export target, and Blender 5.0 has
+# dropped its native Collada exporter.  So KiCad gives us a GLB, and we convert
+# that to Collada inside Blender using pycollada (a pure-Python library we drop
+# into a throwaway venv - we never touch the Blender install and never need sudo).
+#
+# Usage:
+#   tools/export-3d.sh [path/to/board.kicad_pcb]
+#
+# Defaults to the repo's bornhack2026-hardware.kicad_pcb.  Outputs land next to
+# the repo root as <NAME>.glb and <NAME>.dae (override the directory with $OUTDIR).
+#
+# Environment overrides:
+#   KICAD_CLI            path to kicad-cli            (default: autodetected)
+#   BLENDER              path to the Blender binary   (default: autodetected)
+#   KICAD9_3DMODEL_DIR   KiCad 3D model library dir   (default: autodetected)
+#   VENV_DIR             pycollada venv location      (default: tools/.venv-3d)
+#   OUTDIR               output directory             (default: repo root)
+#
+set -euo pipefail
+
+# Pin pycollada for reproducible output.
+PYCOLLADA_VERSION="0.9.3"
+
+# --- Locate ourselves & the repo root, robust to CWD and spaces -------------
+# (resolve the real path of this script even if invoked via a symlink)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+info() { echo ">> $*"; }
+
+# --- Resolve the input PCB --------------------------------------------------
+PCB="${1:-$REPO_ROOT/bornhack2026-hardware.kicad_pcb}"
+[ -f "$PCB" ] || die "PCB file not found: $PCB"
+
+# NAME = the PCB basename without its .kicad_pcb extension.
+PCB_BASE="$(basename "$PCB")"
+NAME="${PCB_BASE%.kicad_pcb}"
+
+OUTDIR="${OUTDIR:-$REPO_ROOT}"
+mkdir -p "$OUTDIR"
+GLB="$OUTDIR/$NAME.glb"
+DAE="$OUTDIR/$NAME.dae"
+
+# --- Locate kicad-cli -------------------------------------------------------
+if [ -n "${KICAD_CLI:-}" ]; then
+    command -v "$KICAD_CLI" >/dev/null 2>&1 || die "\$KICAD_CLI is set but not executable: $KICAD_CLI"
+elif command -v kicad-cli >/dev/null 2>&1; then
+    KICAD_CLI="kicad-cli"
+else
+    die "kicad-cli not found. Install KiCad 10, or set \$KICAD_CLI to its path.
+       On macOS it usually lives at /Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+fi
+
+# --- Locate Blender ---------------------------------------------------------
+# We only need a Blender with a bundled Python (>=4 ships 3.11+, 5.0 ships 3.13).
+# Older Collada-capable Blenders are deliberately NOT special-cased: we keep one
+# deterministic GLB->pycollada path for every version.
+if [ -n "${BLENDER:-}" ]; then
+    command -v "$BLENDER" >/dev/null 2>&1 || die "\$BLENDER is set but not executable: $BLENDER"
+else
+    BLENDER=""
+    # First try plain PATH names (Linux distro packages, manual installs on PATH).
+    for cand in blender blender-5.1 blender-5.0 blender-4.5 blender-4.4 blender-4.3 blender-4.2; do
+        if command -v "$cand" >/dev/null 2>&1; then
+            BLENDER="$cand"
+            break
+        fi
+    done
+    # Then probe the macOS .app bundle, whose binary is NOT on PATH by default.
+    if [ -z "$BLENDER" ]; then
+        for app in \
+            /Applications/Blender.app/Contents/MacOS/Blender \
+            "$HOME/Applications/Blender.app/Contents/MacOS/Blender"; do
+            if [ -x "$app" ]; then
+                BLENDER="$app"
+                break
+            fi
+        done
+    fi
+    [ -n "$BLENDER" ] || die "Blender not found. Install Blender >=4, or set \$BLENDER to its path.
+       Tried PATH names: blender, blender-5.1, blender-5.0, blender-4.5, blender-4.4, blender-4.3, blender-4.2
+       On macOS it usually lives at /Applications/Blender.app/Contents/MacOS/Blender"
+fi
+
+# Soft version check: warn (do not fail) if we can tell it is older than 5.0.
+BLENDER_VER="$("$BLENDER" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)"
+if [ -n "$BLENDER_VER" ]; then
+    BL_MAJOR="${BLENDER_VER%%.*}"
+    if [ "$BL_MAJOR" -lt 5 ] 2>/dev/null; then
+        info "Note: Blender $BLENDER_VER (<5.0) detected; using the same GLB->pycollada path anyway."
+    fi
+fi
+
+# --- Locate KiCad 3D model dir (for KICAD9_3DMODEL_DIR substitution) ---------
+# KiCad footprints reference \${KICAD9_3DMODEL_DIR}.  If it is unset KiCad still
+# finds its own default install dir on most systems, but passing -D makes the
+# export deterministic, so we probe common locations.
+MODEL_DIR="${KICAD9_3DMODEL_DIR:-}"
+if [ -z "$MODEL_DIR" ]; then
+    for d in \
+        /usr/share/kicad/3dmodels \
+        /usr/local/share/kicad/3dmodels \
+        /Applications/KiCad/KiCad.app/Contents/SharedSupport/3dmodels \
+        "$HOME/.local/share/kicad/3dmodels"; do
+        if [ -d "$d" ]; then
+            MODEL_DIR="$d"
+            break
+        fi
+    done
+fi
+
+# --- Provision pycollada into a throwaway venv (no sudo, no Blender changes) -
+VENV_DIR="${VENV_DIR:-$REPO_ROOT/tools/.venv-3d}"
+VENV_PY="$VENV_DIR/bin/python"
+# Test on the interpreter, not just the dir, so an empty/corrupt/interrupted
+# venv (a leftover directory with no usable python) is rebuilt rather than
+# tripping a confusing failure later.
+if [ ! -x "$VENV_PY" ]; then
+    command -v python3 >/dev/null 2>&1 || die "python3 not found (needed to create the pycollada venv)."
+    if [ -d "$VENV_DIR" ]; then
+        info "Existing venv at $VENV_DIR looks incomplete; recreating it."
+        rm -rf "$VENV_DIR"
+    fi
+    info "Creating pycollada venv at: $VENV_DIR"
+    python3 -m venv "$VENV_DIR" || die "failed to create venv at $VENV_DIR"
+fi
+[ -x "$VENV_PY" ] || die "venv python missing/not executable: $VENV_PY
+       (delete $VENV_DIR and re-run to recreate the venv)"
+
+# Make sure the venv actually has pip.  On Debian/Ubuntu without the
+# python3-venv package, 'python3 -m venv' creates a venv with no pip, which
+# would otherwise fail later with a misleading 'check your network' message.
+if ! "$VENV_PY" -m pip --version >/dev/null 2>&1; then
+    info "venv has no pip; bootstrapping with ensurepip..."
+    "$VENV_PY" -m ensurepip --upgrade >/dev/null 2>&1 \
+        || die "venv has no pip and ensurepip is unavailable.
+       Install the python3-venv / python3-pip package for your python3 and re-run."
+fi
+
+# Cache: only pip-install if pycollada is not already importable in the venv.
+if "$VENV_PY" -c 'import collada' >/dev/null 2>&1; then
+    info "pycollada already present in venv (skipping install)."
+else
+    info "Installing pycollada==$PYCOLLADA_VERSION into venv (needs network on first run)..."
+    "$VENV_PY" -m pip install --upgrade pip >/dev/null 2>&1 || true
+    "$VENV_PY" -m pip install "pycollada==$PYCOLLADA_VERSION" \
+        || die "pip install pycollada==$PYCOLLADA_VERSION failed.
+       Check your network connection (first run needs it), or that the venv has
+       a working pip (install the python3-venv / python3-pip package)."
+fi
+
+# Compute the venv's purelib site-packages dir; that is what the Blender script
+# appends to sys.path so Blender's bundled numpy is never shadowed.  Capture in
+# its own 'if' so a non-zero exit is caught by the guard rather than aborting
+# the whole script via set -e on the bare assignment.
+if ! PYCOLLADA_SITE="$("$VENV_PY" -c 'import sysconfig;print(sysconfig.get_path("purelib"))')"; then
+    die "could not query venv site-packages dir from $VENV_PY"
+fi
+[ -d "$PYCOLLADA_SITE" ] || die "venv site-packages dir does not exist (got: '$PYCOLLADA_SITE')"
+
+# --- Failure hint: outputs may be left in an inconsistent state -------------
+# We write each output to a temp file and atomically mv it into place only on
+# success (below), so a mid-run failure never overwrites a previously-good
+# artifact.  This trap just reminds the user if anything bailed out.
+trap 'rc=$?; [ "$rc" -ne 0 ] && echo "export-3d.sh failed (rc=$rc); outputs left unchanged." >&2' EXIT
+
+# --- Step 1: PCB -> GLB via kicad-cli ---------------------------------------
+info "Exporting GLB:  $GLB"
+GLB_TMP="$GLB.tmp.$$"
+KICAD_ARGS=(pcb export glb --include-silkscreen --include-soldermask --subst-models)
+if [ -n "$MODEL_DIR" ]; then
+    info "Using KiCad 3D model dir: $MODEL_DIR"
+    KICAD_ARGS+=(-D "KICAD9_3DMODEL_DIR=$MODEL_DIR")
+else
+    info "No KiCad 3D model dir found; relying on KiCad's built-in default."
+fi
+KICAD_ARGS+=(-f -o "$GLB_TMP" "$PCB")
+# Note: warnings about missing FPC1 / L1 models are EXPECTED and harmless -
+# those two footprints are not in the standard KiCad 3D model library.
+"$KICAD_CLI" "${KICAD_ARGS[@]}" || { rm -f "$GLB_TMP"; die "kicad-cli GLB export failed."; }
+[ -s "$GLB_TMP" ] || { rm -f "$GLB_TMP"; die "GLB export produced no/empty file."; }
+mv -f "$GLB_TMP" "$GLB"
+
+# --- Step 2: GLB -> DAE via Blender + pycollada -----------------------------
+info "Converting GLB -> DAE with Blender ($BLENDER)..."
+DAE_TMP="$DAE.tmp.$$"
+"$BLENDER" --background --factory-startup \
+    --python "$SCRIPT_DIR/glb_to_dae.py" -- \
+    --glb "$GLB" --dae "$DAE_TMP" --pycollada "$PYCOLLADA_SITE" \
+    || { rm -f "$DAE_TMP"; die "Blender GLB->DAE conversion failed."; }
+[ -s "$DAE_TMP" ] || { rm -f "$DAE_TMP"; die "DAE conversion produced no/empty file."; }
+mv -f "$DAE_TMP" "$DAE"
+
+# --- Report -----------------------------------------------------------------
+glb_size="$(du -h "$GLB" | cut -f1)"
+dae_size="$(du -h "$DAE" | cut -f1)"
+echo
+info "Done. Generated:"
+echo "    $GLB   ($glb_size)"
+echo "    $DAE   ($dae_size)"

--- a/tools/glb_to_dae.py
+++ b/tools/glb_to_dae.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Convert a KiCad-exported GLB into a Collada (.dae) file, inside Blender.
+
+This script is meant to be run by Blender's bundled Python, e.g.:
+
+    blender --background --factory-startup \
+        --python tools/glb_to_dae.py -- \
+        --glb in.glb --dae out.dae --pycollada /path/to/site-packages
+
+(It is not executable on purpose: it is only ever invoked via
+``blender --python``, never directly, so it carries no exec bit.)
+
+Why this exists
+---------------
+KiCad has no native DAE/Collada export target, and Blender 5.0 removed its
+own Collada exporter (``bpy.ops.wm.collada_export`` is now a non-functional
+stub).  So we let KiCad produce a GLB, import that here, and write the DAE
+ourselves with ``pycollada`` (a pure-Python library, so it loads happily on
+top of Blender's bundled numpy without any compiled extensions).
+
+The actual GLB->DAE export logic is byte-for-byte the verified pipeline; the
+only thing parameterised here is where the inputs/outputs live and where the
+pycollada package can be found, all passed in via argv after ``--``.
+"""
+
+import argparse
+import sys
+
+
+def parse_args(argv):
+    """Parse the args that appear AFTER the Blender ``--`` separator.
+
+    Blender swallows everything before ``--`` for itself; anything after it is
+    ours.  If ``--`` is absent (e.g. the script is run outside Blender) we just
+    parse the whole argv tail.
+    """
+    if "--" in argv:
+        argv = argv[argv.index("--") + 1:]
+    else:
+        argv = argv[1:]
+    p = argparse.ArgumentParser(
+        prog="glb_to_dae.py",
+        description="Convert a GLB to Collada (.dae) using Blender + pycollada.",
+    )
+    p.add_argument("--glb", required=True, help="Input .glb path")
+    p.add_argument("--dae", required=True, help="Output .dae path")
+    p.add_argument(
+        "--pycollada",
+        required=True,
+        help="site-packages dir of the venv that has pycollada installed",
+    )
+    return p.parse_args(argv)
+
+
+def main():
+    args = parse_args(sys.argv)
+
+    # Append (do NOT prepend) the venv's site-packages so Blender's own bundled
+    # numpy / packages always take precedence and are never shadowed by anything
+    # in the venv.  pycollada is pure Python, so this is all it needs.
+    sys.path.append(args.pycollada)
+
+    try:
+        import bpy
+    except ImportError:
+        sys.exit(
+            "ERROR: 'bpy' not importable. Run this with Blender:\n"
+            "  blender --background --factory-startup --python tools/glb_to_dae.py -- ..."
+        )
+
+    try:
+        import numpy as np
+        import collada
+        from collada import (
+            Collada,
+            source,
+            geometry as cgeom,
+            material as cmat,
+            scene as cscene,
+        )
+    except ImportError as exc:
+        sys.exit(
+            "ERROR: failed to import pycollada/numpy from the provided "
+            "site-packages dir (%s): %s\n"
+            "Make sure tools/export-3d.sh provisioned the venv correctly."
+            % (args.pycollada, exc)
+        )
+
+    # --- Import the GLB into a clean, factory-default Blender scene ----------
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    # The glTF importer is a bundled add-on; it is enabled by default under
+    # --factory-startup (verified on Blender 5.0), but enable it defensively so
+    # this also works on Blender builds/versions where it is not pre-enabled.
+    # enable() is idempotent, so this is a no-op when it is already on.
+    try:
+        import addon_utils
+        addon_utils.enable("io_scene_gltf2", default_set=False)
+    except Exception:  # noqa: BLE001 - if this fails the import below reports it
+        pass
+    try:
+        bpy.ops.import_scene.gltf(filepath=args.glb)
+    except Exception as exc:  # noqa: BLE001 - surface any importer failure clearly
+        sys.exit("ERROR: glTF import of %r failed: %s" % (args.glb, exc))
+
+    mesh_objs = [o for o in bpy.context.scene.objects if o.type == "MESH"]
+    if not mesh_objs:
+        sys.exit("ERROR: no mesh objects found after importing %r" % args.glb)
+
+    # --- Build the Collada document -----------------------------------------
+    mesh = Collada()
+    mesh.assetInfo.upaxis = collada.asset.UP_AXIS.Z_UP
+
+    def base_color(blmat):
+        """Best-effort RGBA for a Blender material (Principled BSDF, else diffuse)."""
+        if blmat and blmat.use_nodes:
+            for n in blmat.node_tree.nodes:
+                if n.type == "BSDF_PRINCIPLED":
+                    c = n.inputs["Base Color"].default_value
+                    return (c[0], c[1], c[2], c[3])
+        if blmat:
+            c = blmat.diffuse_color
+            return (c[0], c[1], c[2], c[3])
+        return (0.75, 0.75, 0.75, 1.0)
+
+    mat_index = {}
+
+    def get_mat(blmat):
+        """Return (collada material, symbol) for a Blender material, creating once."""
+        key = blmat.name if blmat else "__default__"
+        if key in mat_index:
+            return mat_index[key]
+        r, g, b, a = base_color(blmat)
+        sym = "mat%d" % len(mat_index)
+        eff = cmat.Effect(
+            "eff_%s" % sym,
+            [],
+            "phong",
+            diffuse=(r, g, b),
+            specular=(0.1, 0.1, 0.1),
+            shininess=16.0,
+            double_sided=True,
+        )
+        cm = cmat.Material("material_%s" % sym, key, eff)
+        mesh.effects.append(eff)
+        mesh.materials.append(cm)
+        mat_index[key] = (cm, sym)
+        return mat_index[key]
+
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    nodes = []
+    gi = 0
+    for obj in mesh_objs:
+        ev = obj.evaluated_get(depsgraph)
+        me = ev.to_mesh()
+        if len(me.vertices) == 0:
+            ev.to_mesh_clear()
+            continue
+        me.calc_loop_triangles()
+
+        verts = np.empty(len(me.vertices) * 3, dtype=np.float32)
+        me.vertices.foreach_get("co", verts)
+        norms = np.empty(len(me.vertices) * 3, dtype=np.float32)
+        me.vertices.foreach_get("normal", norms)
+
+        gid = "geom%d" % gi
+        src_v = source.FloatSource(gid + "-v", verts, ("X", "Y", "Z"))
+        src_n = source.FloatSource(gid + "-n", norms, ("X", "Y", "Z"))
+        geom = cgeom.Geometry(mesh, gid, obj.name, [src_v, src_n])
+
+        slot_mats = (
+            [s.material for s in obj.material_slots] if obj.material_slots else [None]
+        )
+        by_slot = {}
+        for tri in me.loop_triangles:
+            by_slot.setdefault(tri.material_index, []).append(tri.vertices)
+
+        matnodes = []
+        for slot, tris in by_slot.items():
+            blmat = slot_mats[slot] if slot < len(slot_mats) else None
+            cm, sym = get_mat(blmat)
+            idx = np.array(tris, dtype=np.int64).reshape(-1, 1)
+            indices = np.hstack([idx, idx]).reshape(-1)
+            il = source.InputList()
+            il.addInput(0, "VERTEX", "#" + gid + "-v")
+            il.addInput(1, "NORMAL", "#" + gid + "-n")
+            ts = geom.createTriangleSet(indices, il, sym)
+            geom.primitives.append(ts)
+            matnodes.append(cscene.MaterialNode(sym, cm, inputs=[]))
+
+        mesh.geometries.append(geom)
+
+        M = obj.matrix_world
+        flat = [M[r][c] for r in range(4) for c in range(4)]
+        tf = cscene.MatrixTransform(np.array(flat, dtype=np.float32))
+        geomnode = cscene.GeometryNode(geom, matnodes)
+        nodes.append(
+            cscene.Node(
+                "node_%d_%s" % (gi, obj.name),
+                children=[geomnode],
+                transforms=[tf],
+            )
+        )
+        ev.to_mesh_clear()
+        gi += 1
+
+    myscene = cscene.Scene("scene", nodes)
+    mesh.scenes.append(myscene)
+    mesh.scene = myscene
+    mesh.write(args.dae)
+
+    # Final line the orchestrator greps for to confirm success.
+    print("WROTE_DAE geometries=%d materials=%d" % (gi, len(mat_index)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

Adds a reproducible, one-command pipeline to export the badge's 3D model as **GLB** (glTF) and **DAE** (Collada) for use in 3D projects (Blender, Godot, etc.).

KiCad has **no native DAE/Collada export** target, and **Blender 5.0 removed its own Collada exporter** (`bpy.ops.wm.collada_export` is now a non-functional stub). So we go in two steps:

1. **PCB → GLB** via `kicad-cli` (KiCad 10 exports GLB natively).
2. **GLB → DAE** inside Blender — import the GLB, then write the Collada file with [`pycollada`](https://pypi.org/project/pycollada/). pycollada is pure-Python, so it loads on top of Blender's bundled numpy with **no compiled extensions and no changes to your Blender install**.

## Usage

```sh
tools/export-3d.sh
```

Writes `bornhack2026-hardware.glb` and `bornhack2026-hardware.dae` to the repo root. Pass a different board as the first arg; override autodetection with `KICAD_CLI` / `BLENDER` / `KICAD9_3DMODEL_DIR` / `VENV_DIR` / `OUTDIR`.

## What's in the box

- **`tools/export-3d.sh`** — orchestrator: autodetects `kicad-cli`, Blender (PATH names + macOS `.app` bundle), and the KiCad 3D model dir; provisions `pycollada` into a throwaway venv (no sudo); writes outputs via atomic temp files so a mid-run failure never clobbers a good artifact.
- **`tools/glb_to_dae.py`** — the Blender-driven GLB→DAE exporter. Keeps per-component structure and materials.
- **`readme.md`** — new "3D model export" section (usage, prerequisites, notes).
- **`.gitignore`** — ignores the generated `.glb`/`.dae`, the tooling venv (`tools/.venv-3d/`), and Python caches. The models are large and fully regenerable, so they're **not** committed.

## Result (verified end-to-end)

On Blender 5.0.1 + KiCad 10, `tools/export-3d.sh` (run from an unrelated CWD, with no pre-existing venv) produces a DAE that reloads as:

| Property | Value |
|---|---|
| Geometries | 171 (per-component, selectable) |
| Materials | 52, each with its diffuse color |
| Scene nodes | 171, each with a world transform |
| Triangles | 191,166 |
| Up axis | Z-up |

## Notes / caveats

- During GLB export KiCad warns that the `FPC1` (TE FFC connector) and `L1` (Vishay IFSC-1515 inductor) component models are missing — **expected and harmless**: those two footprints aren't in the standard KiCad 3D model library, so they simply don't appear in the model.
- First run needs network access (to `pip install` pycollada, pinned to `0.9.3`); subsequent runs reuse the cached venv.
- Smooth vertex normals are used (fine for a mostly-flat PCB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)